### PR TITLE
2756-bump-circleci-resource: Updates to xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,9 +296,8 @@ jobs:
       - generate-downloads
   nrrd-preview:
     docker:
-      # This image has the latest cf-cli as well as zero downtime plugins, if needed.
       - image: cimg/node:12.13.1-browsers
-    resource_class: medium+
+    resource_class: xlarge
     steps:
       - checkout
       - restore_cache:
@@ -342,7 +341,7 @@ jobs:
   dev:
     docker:
       - image: cimg/node:12.13-browsers
-    resource_class: medium+
+    resource_class: xlarge
     steps:
       - checkout
       - restore_cache:
@@ -390,7 +389,7 @@ jobs:
     docker:
       # This image has the latest cf-cli as well as zero downtime plugins, if needed.
       - image: cimg/node:12.13-browsers
-    resource_class: medium+
+    resource_class: xlarge
     steps:
       - checkout
       - restore_cache:

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "gatsby clean",
-    "build": "NODE_OPTIONS=--max-old-space-size=4096 gatsby build --prefix-paths",
+    "build": "NODE_OPTIONS=--max-old-space-size=8192 gatsby build --prefix-paths",
     "develop": "gatsby develop",
     "format": "eslint --fix 'src/**'",
     "start": "npm run develop",


### PR DESCRIPTION
Fixes #2756

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/2756-bump-circleci-resource-class-nrrd/)

Changes proposed in this pull request:
- Bumps resource_class to xlarge for website pipeline jobs
- Updates max-old-space-size for Gatsby build to 8192