### PR TITLE
Sets aria-hidden for colored squares

### DIFF
--- a/database/changelog/changelog-functions/disbursement-functions-refactor.yaml
+++ b/database/changelog/changelog-functions/disbursement-functions-refactor.yaml
@@ -2,7 +2,6 @@ databaseChangeLog:
   - changeSet:
       id: refactor-disbursement-functions
       author: Jeff Schwartz
-      runOnChange: true
       changes:
       - sqlFile:
           path: src/functions/format_negative_disbursement.sql

--- a/database/changelog/changelog-functions/disbursement-functions-refactor.yaml
+++ b/database/changelog/changelog-functions/disbursement-functions-refactor.yaml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: refactor-disbursement-functions
       author: Jeff Schwartz
+      runOnChange: false
       changes:
       - sqlFile:
           path: src/functions/format_negative_disbursement.sql

--- a/database/changelog/changelog-functions/production-fy-refactor-functions.yaml
+++ b/database/changelog/changelog-functions/production-fy-refactor-functions.yaml
@@ -2,7 +2,6 @@ databaseChangeLog:
   - changeSet:
       id: refactor-production-fy-functions
       author: Jeff Schwartz
-      runOnChange: true
       changes:
       - sqlFile:
           path: src/functions/ignore_empty_production_fy.sql

--- a/database/changelog/changelog-functions/production-refactor-functions.yaml
+++ b/database/changelog/changelog-functions/production-refactor-functions.yaml
@@ -2,7 +2,6 @@ databaseChangeLog:
   - changeSet:
       id: refactor-production-functions
       author: Jeff Schwartz
-      runOnChange: true
       changes:
       - sqlFile:
           path: src/functions/format_volume.sql

--- a/database/changelog/changelog-functions/revenue-functions-refactor.yaml
+++ b/database/changelog/changelog-functions/revenue-functions-refactor.yaml
@@ -2,7 +2,6 @@ databaseChangeLog:
   - changeSet:
       id: refactor-revenue-functions
       author: Jeff Schwartz
-      runOnChange: true
       changes:
       - sqlFile:
           path: src/functions/format_negative_revenue.sql

--- a/database/changelog/changelog-procedures/disbursement-refactor-procedures.yaml
+++ b/database/changelog/changelog-procedures/disbursement-refactor-procedures.yaml
@@ -2,7 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: disbursement-refactor-procedures
       author: Jeff Schwartz
-      runOnChange: false
+      runOnChange: true
       changes:
       - sqlFile:
           path: src/procedures/load_disbursement_monthly.sql

--- a/database/changelog/changelog-procedures/disbursement-refactor-procedures.yaml
+++ b/database/changelog/changelog-procedures/disbursement-refactor-procedures.yaml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: disbursement-refactor-procedures
       author: Jeff Schwartz
+      runOnChange: false
       changes:
       - sqlFile:
           path: src/procedures/load_disbursement_monthly.sql

--- a/database/changelog/changelog-procedures/disbursement-refactor-procedures.yaml
+++ b/database/changelog/changelog-procedures/disbursement-refactor-procedures.yaml
@@ -2,7 +2,6 @@ databaseChangeLog:
   - changeSet:
       id: disbursement-refactor-procedures
       author: Jeff Schwartz
-      runOnChange: true
       changes:
       - sqlFile:
           path: src/procedures/load_disbursement_monthly.sql

--- a/database/changelog/changelog-procedures/revenue-procedures-refactor.yaml
+++ b/database/changelog/changelog-procedures/revenue-procedures-refactor.yaml
@@ -2,7 +2,6 @@ databaseChangeLog:
   - changeSet:
       id: refactor-revenue-procedures
       author: Jeff Schwartz
-      runOnChange: true
       changes:
       - sqlFile:
           path: src/procedures/summarize_native_american_revenue.sql

--- a/src/components/data-viz/StackedBarChart/D3StackedBarChart.js
+++ b/src/components/data-viz/StackedBarChart/D3StackedBarChart.js
@@ -723,7 +723,6 @@ export default class D3StackedBarChart {
 
           rect.setAttribute('width', 10)
           rect.setAttribute('height', 10)
-          rect.setAttribute('aria-hidden', true)
 
           rect.style.backgroundColor = color(i)
           rect.style.border = `1px solid ${ color(i) }`
@@ -733,6 +732,7 @@ export default class D3StackedBarChart {
           const svg = document.createElement('svg')
 
           svg.setAttribute('viewBox', '0 0 10 10')
+          svg.setAttribute('aria-hidden', true)
 
           svg.style.fill = color(i)
 

--- a/src/components/data-viz/StackedBarChart/D3StackedBarChart.js
+++ b/src/components/data-viz/StackedBarChart/D3StackedBarChart.js
@@ -723,6 +723,7 @@ export default class D3StackedBarChart {
 
           rect.setAttribute('width', 10)
           rect.setAttribute('height', 10)
+          rect.setAttribute('aria-hidden', true)
 
           rect.style.backgroundColor = color(i)
           rect.style.border = `1px solid ${ color(i) }`

--- a/src/components/data-viz/svg/Rect.js
+++ b/src/components/data-viz/svg/Rect.js
@@ -7,7 +7,8 @@ const Rect = ({
   x = 0,
   y = 0,
   styles,
-  title
+  title,
+  ariaHidden = true
 }) => {
   return (
     <svg width={width} height={height} style={styles} title={title}>
@@ -18,7 +19,8 @@ const Rect = ({
         height={height}
         x={x}
         y={y}
-        style={styles} />
+        style={styles}
+        aria-hidden={ariaHidden}/>
     </svg>
   )
 }
@@ -28,5 +30,6 @@ export default Rect
 Rect.propTypes = {
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  title: PropTypes.string
+  title: PropTypes.string,
+  ariaHidden: PropTypes.bool
 }

--- a/src/components/data-viz/svg/Rect.js
+++ b/src/components/data-viz/svg/Rect.js
@@ -7,11 +7,10 @@ const Rect = ({
   x = 0,
   y = 0,
   styles,
-  title,
-  ariaHidden = true
+  title
 }) => {
   return (
-    <svg width={width} height={height} style={styles} title={title}>
+    <svg width={width} height={height} style={styles} title={title} aria-hidden="true">
       <title>{title}</title>
       <rect
         className="rect"
@@ -19,8 +18,7 @@ const Rect = ({
         height={height}
         x={x}
         y={y}
-        style={styles}
-        aria-hidden={ariaHidden}/>
+        style={styles}/>
     </svg>
   )
 }
@@ -30,6 +28,5 @@ export default Rect
 Rect.propTypes = {
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  title: PropTypes.string,
-  ariaHidden: PropTypes.bool
+  title: PropTypes.string
 }


### PR DESCRIPTION
Fixes #2729

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/2729-colored-squares/)

Changes proposed in this pull request:

- Adds `aria-hidden` attribute to `svg` elements for colored squares