### PR TITLE
2978: Removes redundant GA script

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -84,12 +84,6 @@ function SEO ({ description, lang, meta, title, keywords }) {
 
         {/* Digital Analytics Program roll-up, see the data at https://analytics.usa.gov */}
         <script src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOI&subagency=ONRR" id="_fed_an_ua_tag" async type="text/javascript"></script>
-
-        {defaults.googleAnalyticsId &&
-          <script>
-            {`(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');ga('create', '${ defaults.googleAnalyticsId }', 'auto');ga('set', 'anonymizeIp', true);ga('set', 'forceSSL', true);ga('send', 'pageview');`}
-          </script>
-        }
       </Helmet>
     </Fragment>
   )


### PR DESCRIPTION
Fixes #2978

[:sunglasses: PREVIEW](https://nrrd-preview.app.cloud.gov/sites/2978-remove-dap-tag/)

Changes proposed in this pull request:

- Removes redundant google analytics script tag