### PR TITLE
Fixes database backup failures in the automated workflow

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -53,12 +53,19 @@ jobs:
           cf login -u ${{ secrets.CF_USERNAME }} -p ${{ secrets.CF_PASSWORD }} -a api.fr.cloud.gov -o doi-onrr -s "$CF_SPACE"
 
       - name: Backup database
-        working-directory: ${{ github.workspace }}
-        run: |
-          cg-manage-rds export -o "-F p --no-owner --no-acl" -f backup.sql "$DB_SERVICE" 2>&1 | cat
-
-      - name: Verify backup file
-        run: ls -lh backup.sql
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 30
+          shell: bash
+          command: |
+            set -eo pipefail
+            cd "${{ github.workspace }}"
+            rm -f backup.sql
+            cg-manage-rds export -o "-F p --no-owner --no-acl" -f backup.sql "$DB_SERVICE" 2>&1
+            test -s backup.sql
+            ls -lh backup.sql
 
       - name: Compress backup
         run: |


### PR DESCRIPTION
## Summary

Fixes database backup failures in the automated workflow by adding retry logic and improving error handling for the `cg-manage-rds export` command.

## What Changed

- Wrapped the database backup step with a retry action (`nick-fields/retry@v3`)
- Added 3 retry attempts with 30-second intervals and a 30-minute timeout per attempt
- Combined backup and verification into a single step with proper error handling (`set -eo pipefail`)
- Added cleanup to remove any existing `backup.sql` file before attempting backup
- Added explicit verification that backup file exists and is non-empty (`test -s backup.sql`)

## Why

The database backup workflow was experiencing intermittent failures, likely due to transient network issues or temporary service unavailability when connecting to the Cloud Foundry database service. This change addresses issue #4362 by making the backup process more resilient to temporary failures.

## Implementation Notes

The retry logic and verification are combined into a single step to ensure that each retry attempt performs a complete backup-and-verify cycle rather than potentially verifying a stale or incomplete file from a previous failed attempt.